### PR TITLE
Auto-generate documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ TOPDIR = $(shell git rev-parse --show-toplevel)
 PYDIRS="vmanage"
 VENV = venv_python_viptela
 VENV_BIN=$(VENV)/bin
+SRC_FILES := $(shell find vmanage -name \*.py)
+SPHINX_DEPS := $(shell find docs/src)
+NON_PYTHON_LIBS := $(shell ls | grep -v vmanage)
 
 help: ## Display help
 	@awk -F ':|##' \
@@ -65,19 +68,32 @@ test: deps ## Run python-viptela tests
 
 clean: ## Clean python-viptela $(VENV)
 	$(RM) -rf $(VENV)
-	$(RM) -rf docs/build
+	$(RM) -rf docs/_build
 	$(RM) -rf dist
 	$(RM) -rf *.egg-info
 	$(RM) -rf *.eggs
+	$(RM) -rf docs/api/*
 	find . -name "*.pyc" -exec $(RM) -rf {} \;
 
-build-container:
-	docker build --no-cache -t $(CIMC_CLI_REGISTRY)/$(CIMC_CLI_NAMESPACE)/python-viptela:$(CIMC_CLI_VERSION) .
+clean-docs-html:
+	$(RM) -rf docs/build/html
+clean-docs-markdown:
+	$(RM) -rf docs/build/markdown
 
-push-container:
-	docker push $(CIMC_CLI_REGISTRY)/$(CIMC_CLI_NAMESPACE)/python-viptela:$(CIMC_CLI_VERSION)
+apidocs: docs/source/modules.rst ## regenerate API documention sources
 
-clean-container:
-	docker rmi $(CIMC_CLI_REGISTRY)/$(CIMC_CLI_NAMESPACE)/python-viptela:$(CIMC_CLI_VERSION)
+docs/source/modules.rst: $(SRC_FILES)  $(VENV)/bin/activate
+	$(VENV_BIN)/sphinx-apidoc -M -fo docs/api . $(NON_PYTHON_LIBS)
 
-.PHONY: all clean $(VENV) test check format check-format pylint
+docs: docs-markdown docs-html ## Generate documentation in HTML and Markdown
+
+docs-markdown: clean-docs-markdown $(SPHINX_DEPS) $(VENV)/bin/activate ## Generate Markdown documentation
+	$(MAKE) -C docs markdown
+docs-html: clean-docs-html $(SPHINX_DEPS) $(VENV)/bin/activate ## Generate HTML documentation
+	$(MAKE) -C docs html
+
+docs-clean: ## Clean generated documentation
+	$(MAKE) -C docs clean
+
+
+.PHONY: all clean $(VENV) test check format check-format pylint clean-docs-html clean-docs-markdown apidocs

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ docs/source/modules.rst: $(SRC_FILES)  $(VENV)/bin/activate
 docs: docs-markdown docs-html ## Generate documentation in HTML and Markdown
 
 docs-markdown: clean-docs-markdown $(SPHINX_DEPS) $(VENV)/bin/activate ## Generate Markdown documentation
-	$(MAKE) -C docs markdown
+	. $(VENV_BIN)/activate ; $(MAKE) -C docs markdown
 docs-html: clean-docs-html $(SPHINX_DEPS) $(VENV)/bin/activate ## Generate HTML documentation
-	$(MAKE) -C docs html
+	. $(VENV_BIN)/activate ; $(MAKE) -C docs html
 
 docs-clean: ## Clean generated documentation
 	$(MAKE) -C docs clean

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ vmanage import policies --file vmanage-policies.json
 
 ##### Diff two templates
 
-```
+```bash
 vmanage show template g0/0/0-R1 --diff g0/0/0-R2
 [ ( 'change',
     'templateDefinition.tunnel-interface.color.value.vipType',
@@ -183,8 +183,4 @@ vmanage show template g0/0/0-R1 --diff g0/0/0-R2
 
 ## License
 
-<<<<<<< HEAD
-GPLv3
-=======
 CISCO SAMPLE CODE LICENSE
->>>>>>> master

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,62 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../vmanage'))
+sys.path.insert(0, os.path.abspath('../..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Python vManage'
+copyright = '2020, Cisco Public Sector'
+author = 'Cisco Public Sector'
+
+# The full version, including alpha/beta/rc tags
+release = '0.2.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+  'sphinx.ext.autodoc',
+  'sphinx.ext.napoleon',
+  "sphinx_rtd_theme",
+  'sphinx.ext.todo',
+  'sphinx.ext.viewcode',
+  'm2r'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. Python vManage documentation master file, created by
+   sphinx-quickstart on Wed Apr 15 09:30:55 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Python vManage's documentation!
+==========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ Click
 dictdiffer
 PyYAML
 requests
+sphinx>=2.1.2,<3.0
+sphinx-markdown==1.0.2
+sphinx-markdown-builder==0.5.4
+sphinx_rtd_theme==0.4.3
+m2r==0.2.1

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
     install_requires=['Click', 'requests', 'dictdiffer', 'PyYAML'],
     entry_points='''
         [console_scripts]
-        vmanage=vmanage.__main__:vmanage     
+        vmanage=vmanage.__main__:vmanage
     ''',
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,5 @@ mock==1.0.1
 pylint==2.4.4
 pytest==2.8.7
 pytest-cov==2.3.1
-sphinx==1.6.3
-sphinx_rtd_theme==0.2.5b1
 tox==2.6.0
 yapf==0.29.0

--- a/vmanage/__main__.py
+++ b/vmanage/__main__.py
@@ -13,7 +13,7 @@ from vmanage.api.authentication import Authentication
 class CatchAllExceptions(click.Group):
     def __call__(self, *args, **kwargs):
         try:
-            return self.main(*args, **kwargs)
+            return self.vmanage(*args, **kwargs)
         except Exception as exc:
             click.secho('Exception raised while running your command', fg="red")
             click.secho("Please open an issue and provide this info:", fg="red")


### PR DESCRIPTION
- Put sphinx framework in place
- add 4 new makefile targets:
  - apidocs: generate API documentation sources (but not output files)
  - docs-markdown: generate Markdown documentation
  - docs-html: generate HTML documentation
  - docs: generate HTML and Markdown documentation
- output is in docs/build/<type>
- drive-by: fix results of bad merge in README.md