### PR TITLE
Issue 70 : support vmanage port number option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,21 @@ pip install -e .
 
 ## Environment Variables
 
-IP/DNS and credentials for the vManage server can be set for the SDK via environment variable
+IP/DNS, port and credentials for the vManage server can be set for the SDK via environment variable
 
 * `VMANAGE_HOST`
+* `VMANAGE_PORT`
 * `VMANAGE_USERNAME`
 * `VMANAGE_PASSWORD`
 
 ## vManage Command Line Interface
 
 ```bash
-$ vmanage --help
 Usage: vmanage [OPTIONS] COMMAND [ARGS]...
 
 Options:
   --host TEXT      vManage Host (env: VMANAGE_HOST)  [required]
+  --port INTEGER   vManage Port (env: VMANAGE_PORT, default=443)
   --username TEXT  vManage Username (env: VMANAGE_USERNAME)  [required]
   --password TEXT  vManage Password (env: VMANAGE_PASSWORD)  [required]
   --help           Show this message and exit.
@@ -66,6 +67,7 @@ Commands:
   deactivate   Deactivate commands
   export       Export commands
   import       Import commands
+  set          vManage Settings set commands
   show         Show commands
 ```
 

--- a/vmanage/__main__.py
+++ b/vmanage/__main__.py
@@ -23,23 +23,26 @@ class CatchAllExceptions(click.Group):
 
 
 class Viptela(object):
-    def __init__(self, host, username, password):
+    def __init__(self, host, port, username, password):
         self.host = host
         self.username = username
         self.password = password
+        self.port = port
         self.__auth = None
 
     # use this to defer authentication until it's needed
     @property
     def auth(self):
         if self.__auth is None:
-            self.__auth = Authentication(host=self.host, user=self.username, password=self.password).login()
+            self.__auth = Authentication(host=self.host, port=self.port, user=self.username,
+                                         password=self.password).login()
         return self.__auth
 
 
 # @click.group(cls=CatchAllExceptions)
 @click.group()
 @click.option('--host', envvar='VMANAGE_HOST', help='vManage Host (env: VMANAGE_HOST)', required=True)
+@click.option('--port', envvar='VMANAGE_PORT', help='vManage Port (env: VMANAGE_PORT)', default=443, required=False)
 @click.option('--username', envvar='VMANAGE_USERNAME', help='vManage Username (env: VMANAGE_USERNAME)', required=True)
 @click.option('--password',
               envvar='VMANAGE_PASSWORD',
@@ -48,8 +51,8 @@ class Viptela(object):
               help='vManage Password (env: VMANAGE_PASSWORD)',
               required=True)
 @click.pass_context
-def vmanage(ctx, host, username, password):
-    ctx.obj = Viptela(host, username, password)
+def vmanage(ctx, host, port, username, password):
+    ctx.obj = Viptela(host, port, username, password)
 
 
 vmanage.add_command(activate)

--- a/vmanage/__main__.py
+++ b/vmanage/__main__.py
@@ -42,7 +42,7 @@ class Viptela(object):
 # @click.group(cls=CatchAllExceptions)
 @click.group()
 @click.option('--host', envvar='VMANAGE_HOST', help='vManage Host (env: VMANAGE_HOST)', required=True)
-@click.option('--port', envvar='VMANAGE_PORT', help='vManage Port (env: VMANAGE_PORT)', default=443, required=False)
+@click.option('--port', envvar='VMANAGE_PORT', help='vManage Port (env: VMANAGE_PORT, default=443)', default=443, required=False)
 @click.option('--username', envvar='VMANAGE_USERNAME', help='vManage Username (env: VMANAGE_USERNAME)', required=True)
 @click.option('--password',
               envvar='VMANAGE_PASSWORD',

--- a/vmanage/__main__.py
+++ b/vmanage/__main__.py
@@ -42,7 +42,11 @@ class Viptela(object):
 # @click.group(cls=CatchAllExceptions)
 @click.group()
 @click.option('--host', envvar='VMANAGE_HOST', help='vManage Host (env: VMANAGE_HOST)', required=True)
-@click.option('--port', envvar='VMANAGE_PORT', help='vManage Port (env: VMANAGE_PORT, default=443)', default=443, required=False)
+@click.option('--port',
+              envvar='VMANAGE_PORT',
+              help='vManage Port (env: VMANAGE_PORT, default=443)',
+              default=443,
+              required=False)
 @click.option('--username', envvar='VMANAGE_USERNAME', help='vManage Username (env: VMANAGE_USERNAME)', required=True)
 @click.option('--password',
               envvar='VMANAGE_PASSWORD',

--- a/vmanage/cli/activate/central_policy.py
+++ b/vmanage/cli/activate/central_policy.py
@@ -10,7 +10,7 @@ def central_policy(ctx, name):
     Activate Central Policy
     """
 
-    vmanage_central_policy = CentralPolicy(ctx.auth, ctx.host)
+    vmanage_central_policy = CentralPolicy(ctx.auth, ctx.host, ctx.port)
     central_policy_dict = vmanage_central_policy.get_central_policy_dict(remove_key=True)
     if name in central_policy_dict:
         click.echo(f'Activating Central Policy {name}')

--- a/vmanage/cli/certificate/generate_csr.py
+++ b/vmanage/cli/certificate/generate_csr.py
@@ -11,7 +11,7 @@ def generate_csr(ctx, ip, csr_file):
     Generate CSR for a device
     """
 
-    vmanage_certificate = Certificate(ctx.auth, ctx.host)
+    vmanage_certificate = Certificate(ctx.auth, ctx.host, ctx.port)
     csr = vmanage_certificate.generate_csr(ip)
     with open(csr_file, 'w') as outfile:
         outfile.write(csr)

--- a/vmanage/cli/certificate/install.py
+++ b/vmanage/cli/certificate/install.py
@@ -10,6 +10,6 @@ def install(ctx, cert):
     Install certificate
     """
 
-    vmanage_certificate = Certificate(ctx.auth, ctx.host)
+    vmanage_certificate = Certificate(ctx.auth, ctx.host, ctx.port)
     click.echo("Installing certificate...")
     vmanage_certificate.install_device_cert(cert)

--- a/vmanage/cli/certificate/push.py
+++ b/vmanage/cli/certificate/push.py
@@ -9,6 +9,6 @@ def push(ctx):
     Push certificates to all controllers
     """
 
-    vmanage_certificate = Certificate(ctx.auth, ctx.host)
+    vmanage_certificate = Certificate(ctx.auth, ctx.host, ctx.port)
     click.echo("Pushing certificates to controllers...")
     vmanage_certificate.push_certificates()

--- a/vmanage/cli/clean.py
+++ b/vmanage/cli/clean.py
@@ -9,7 +9,7 @@ def clean(ctx, verify_clean):
     """
     Clean vManage
     """
-    clean_vmanage = CleanVmanage(ctx.auth, ctx.host)
+    clean_vmanage = CleanVmanage(ctx.auth, ctx.host, ctx.port)
 
     if verify_clean:
         clean_vmanage.clean_all()

--- a/vmanage/cli/deactivate/central_policy.py
+++ b/vmanage/cli/deactivate/central_policy.py
@@ -11,7 +11,7 @@ def central_policy(ctx, name, policy_id):
     deactivate Central Policy
     """
 
-    vmanage_central_policy = CentralPolicy(ctx.auth, ctx.host)
+    vmanage_central_policy = CentralPolicy(ctx.auth, ctx.host, ctx.port)
     central_policy_dict = vmanage_central_policy.get_central_policy_dict(remove_key=True)
     if policy_id:
         vmanage_central_policy.deactivate_central_policy(policy_id)

--- a/vmanage/cli/export/attachments.py
+++ b/vmanage/cli/export/attachments.py
@@ -17,7 +17,7 @@ def attachments(ctx, device_type, name, output_file):
     Export attachments to file
     """
     num = 0
-    vmanage_files = Files(ctx.auth, ctx.host)
+    vmanage_files = Files(ctx.auth, ctx.host, ctx.port)
     if device_type == 'controllers':
         if name:
             click.echo(f'Exporting controller attachment(s) {",".join(name)} to {output_file}')

--- a/vmanage/cli/export/policies.py
+++ b/vmanage/cli/export/policies.py
@@ -14,6 +14,6 @@ def policies(ctx, export_file):
     Export policies to file
     """
 
-    vmanage_files = Files(ctx.auth, ctx.host)
+    vmanage_files = Files(ctx.auth, ctx.host, ctx.port)
     click.echo(f'Exporting policies to {export_file}')
     vmanage_files.export_policy_to_file(export_file)

--- a/vmanage/cli/export/templates.py
+++ b/vmanage/cli/export/templates.py
@@ -16,7 +16,7 @@ def templates(ctx, template_type, name, export_file):
     """
     Export templates to file
     """
-    vmanage_files = Files(ctx.auth, ctx.host)
+    vmanage_files = Files(ctx.auth, ctx.host, ctx.port)
 
     if template_type == 'device':
         if name:

--- a/vmanage/cli/import_cmd/attachments.py
+++ b/vmanage/cli/import_cmd/attachments.py
@@ -19,7 +19,7 @@ def attachments(ctx, input_file, check, update, name, template_type):
     """
     Import attachments from file
     """
-    vmanage_files = Files(ctx.auth, ctx.host)
+    vmanage_files = Files(ctx.auth, ctx.host, ctx.port)
 
     click.echo(f'Importing attachments from {input_file}')
     result = vmanage_files.import_attachments_from_file(input_file,

--- a/vmanage/cli/import_cmd/policies.py
+++ b/vmanage/cli/import_cmd/policies.py
@@ -15,7 +15,7 @@ def policies(ctx, input_file, check, update, push, diff):
     """
     Import policies from file
     """
-    vmanage_files = Files(ctx.auth, ctx.host)
+    vmanage_files = Files(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     click.echo(f"{'Checking' if check else 'Importing'} policies from {input_file}")

--- a/vmanage/cli/import_cmd/root_cert.py
+++ b/vmanage/cli/import_cmd/root_cert.py
@@ -9,5 +9,5 @@ def root_cert(ctx, input_file):
     """
     Import root cert
     """
-    vmanage_settings = Settings(ctx.auth, ctx.host)
+    vmanage_settings = Settings(ctx.auth, ctx.host, ctx.port)
     vmanage_settings.set_vmanage_root_cert(input_file)

--- a/vmanage/cli/import_cmd/serial_file.py
+++ b/vmanage/cli/import_cmd/serial_file.py
@@ -9,7 +9,7 @@ def serial_file(ctx, input_file):
     """
     Import serial file
     """
-    vmanage_utilities = Utilities(ctx.auth, ctx.host)
+    vmanage_utilities = Utilities(ctx.auth, ctx.host, ctx.port)
 
     click.echo(f'Uploading serial file... {input_file}')
     result = vmanage_utilities.upload_file(input_file)

--- a/vmanage/cli/import_cmd/templates.py
+++ b/vmanage/cli/import_cmd/templates.py
@@ -21,7 +21,7 @@ def templates(ctx, input_file, check, update, diff, name, template_type):
     """
     Import templates from file
     """
-    vmanage_files = Files(ctx.auth, ctx.host)
+    vmanage_files = Files(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     click.echo(f'Importing templates from {input_file}')

--- a/vmanage/cli/set_cmd/ca_type.py
+++ b/vmanage/cli/set_cmd/ca_type.py
@@ -10,5 +10,5 @@ def ca_type(ctx, type_):
     Set vManage CA type
     """
 
-    vmanage_settings = Settings(ctx.auth, ctx.host)
+    vmanage_settings = Settings(ctx.auth, ctx.host, ctx.port)
     vmanage_settings.set_vmanage_ca_type(type_)

--- a/vmanage/cli/set_cmd/central_policy.py
+++ b/vmanage/cli/set_cmd/central_policy.py
@@ -13,7 +13,7 @@ def central_policy(ctx, type_, name, pref_color, seq_name):
     Set Policy sequence statements
     """
 
-    vmanage_policy_updates = PolicyUpdates(ctx.auth, ctx.host)
+    vmanage_policy_updates = PolicyUpdates(ctx.auth, ctx.host, ctx.port)
     policy_id = vmanage_policy_updates.get_policy_id(type_, name)
     policy_def = vmanage_policy_updates.get_policy_definition(type_, policy_id)
     vmanage_policy_updates.update_policy_definition(type_, name, policy_id, policy_def, pref_color, seq_name)

--- a/vmanage/cli/set_cmd/org.py
+++ b/vmanage/cli/set_cmd/org.py
@@ -10,5 +10,5 @@ def org(ctx, org_name):
     Set vManage org
     """
 
-    vmanage_settings = Settings(ctx.auth, ctx.host)
+    vmanage_settings = Settings(ctx.auth, ctx.host, ctx.port)
     vmanage_settings.set_vmanage_org(org_name)

--- a/vmanage/cli/set_cmd/vbond.py
+++ b/vmanage/cli/set_cmd/vbond.py
@@ -11,5 +11,5 @@ def vbond(ctx, ip, port):
     Set vBond
     """
 
-    vmanage_settings = Settings(ctx.auth, ctx.host)
+    vmanage_settings = Settings(ctx.auth, ctx.host, ctx.port)
     vmanage_settings.set_vmanage_vbond(ip, port)

--- a/vmanage/cli/show/ca_type.py
+++ b/vmanage/cli/show/ca_type.py
@@ -9,6 +9,6 @@ def ca_type(ctx):
     Get vManage CA type
     """
 
-    vmanage_settings = Settings(ctx.auth, ctx.host)
+    vmanage_settings = Settings(ctx.auth, ctx.host, ctx.port)
     result = vmanage_settings.get_vmanage_ca_type()
     click.echo(result)

--- a/vmanage/cli/show/control.py
+++ b/vmanage/cli/show/control.py
@@ -15,8 +15,8 @@ def connections(ctx, device, json):
     Show control connections
     """
 
-    vmanage_device = Device(ctx.auth, ctx.host)
-    mn = MonitorNetwork(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
+    mn = MonitorNetwork(ctx.auth, ctx.host, ctx.port)
 
     if device:
         # Check to see if we were passed in a device IP address or a device name
@@ -66,8 +66,8 @@ def connections_history(ctx, device, json):
     Show control connections history
     """
 
-    vmanage_device = Device(ctx.auth, ctx.host)
-    mn = MonitorNetwork(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
+    mn = MonitorNetwork(ctx.auth, ctx.host, ctx.port)
 
     # Check to see if we were passed in a device IP address or a device name
     try:

--- a/vmanage/cli/show/device.py
+++ b/vmanage/cli/show/device.py
@@ -20,7 +20,7 @@ def status(ctx, dev, device_type, json):  #pylint: disable=unused-argument
     Show device status information
     """
 
-    vmanage_device = Device(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
     # output = mn.get_control_connections_history(sysip)
     # vmanage_session = ctx.obj
     pp = pprint.PrettyPrinter(indent=2)
@@ -80,7 +80,7 @@ def config(ctx, dev, device_type, json):
     """
     Show device config information
     """
-    vmanage_device = Device(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     #pylint: disable=too-many-nested-blocks

--- a/vmanage/cli/show/interface.py
+++ b/vmanage/cli/show/interface.py
@@ -13,7 +13,7 @@ def list_interface(ctx, device, json):
     """
     Show Interfaces
     """
-    vmanage_device = Device(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
 
     if device:
         # Check to see if we were passed in a device IP address or a device name

--- a/vmanage/cli/show/omp.py
+++ b/vmanage/cli/show/omp.py
@@ -15,8 +15,8 @@ def peers(ctx, device, json):
     Show OMP peer information
     """
 
-    vmanage_device = Device(ctx.auth, ctx.host)
-    mn = MonitorNetwork(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
+    mn = MonitorNetwork(ctx.auth, ctx.host, ctx.port)
 
     # Check to see if we were passed in a device IP address or a device name
     try:
@@ -54,8 +54,8 @@ def received(ctx, device, json):
     Show OMP peer information
     """
 
-    vmanage_device = Device(ctx.auth, ctx.host)
-    mn = MonitorNetwork(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
+    mn = MonitorNetwork(ctx.auth, ctx.host, ctx.port)
 
     # Check to see if we were passed in a device IP address or a device name
     try:
@@ -92,8 +92,8 @@ def advertised(ctx, device, json):
     Show OMP peer information
     """
 
-    vmanage_device = Device(ctx.auth, ctx.host)
-    mn = MonitorNetwork(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
+    mn = MonitorNetwork(ctx.auth, ctx.host, ctx.port)
 
     # Check to see if we were passed in a device IP address or a device name
     try:

--- a/vmanage/cli/show/org.py
+++ b/vmanage/cli/show/org.py
@@ -9,7 +9,7 @@ def org(ctx):
     Get vManage org
     """
 
-    vmanage_settings = Settings(ctx.auth, ctx.host)
+    vmanage_settings = Settings(ctx.auth, ctx.host, ctx.port)
     result = vmanage_settings.get_vmanage_org()
     if result:
         click.echo(f'{result}')

--- a/vmanage/cli/show/policies.py
+++ b/vmanage/cli/show/policies.py
@@ -19,7 +19,7 @@ def list_cmd(ctx, name, json, policy_list_type):  #pylint: disable=unused-argume
     """
     Show policy list information
     """
-    policy_lists = PolicyLists(ctx.auth, ctx.host)
+    policy_lists = PolicyLists(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     if name:
@@ -45,8 +45,8 @@ def definition(ctx, name, json, definition_type):  #pylint: disable=unused-argum
     """
     Show policy definition information
     """
-    policy_definitions = PolicyDefinitions(ctx.auth, ctx.host)
-    policy_data = PolicyData(ctx.auth, ctx.host)
+    policy_definitions = PolicyDefinitions(ctx.auth, ctx.host, ctx.port)
+    policy_data = PolicyData(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     if name:
@@ -68,8 +68,8 @@ def central(ctx, name, json):  #pylint: disable=unused-argument
     """
     Show central policy information
     """
-    central_policy = CentralPolicy(ctx.auth, ctx.host)
-    policy_data = PolicyData(ctx.auth, ctx.host)
+    central_policy = CentralPolicy(ctx.auth, ctx.host, ctx.port)
+    policy_data = PolicyData(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     if name:
@@ -93,8 +93,8 @@ def local(ctx, name, json):  #pylint: disable=unused-argument
     """
     Show local policy information
     """
-    local_policy = LocalPolicy(ctx.auth, ctx.host)
-    policy_data = PolicyData(ctx.auth, ctx.host)
+    local_policy = LocalPolicy(ctx.auth, ctx.host, ctx.port)
+    policy_data = PolicyData(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     if name:
@@ -114,8 +114,8 @@ def security(ctx, name, json):  #pylint: disable=unused-argument
     """
     Show security policy information
     """
-    security_policy = SecurityPolicy(ctx.auth, ctx.host)
-    policy_data = PolicyData(ctx.auth, ctx.host)
+    security_policy = SecurityPolicy(ctx.auth, ctx.host, ctx.port)
+    policy_data = PolicyData(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     if name:

--- a/vmanage/cli/show/root_cert.py
+++ b/vmanage/cli/show/root_cert.py
@@ -9,6 +9,6 @@ def root_cert(ctx):
     Get vManage root certificate
     """
 
-    vmanage_certificate = Certificate(ctx.auth, ctx.host)
+    vmanage_certificate = Certificate(ctx.auth, ctx.host, ctx.port)
     result = vmanage_certificate.get_vmanage_root_cert()
     click.echo(result)

--- a/vmanage/cli/show/route.py
+++ b/vmanage/cli/show/route.py
@@ -13,7 +13,7 @@ def table(ctx, device, json):
     """
     Show Interfaces
     """
-    vmanage_device = Device(ctx.auth, ctx.host)
+    vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
 
     # Check to see if we were passed in a device IP address or a device name
     try:

--- a/vmanage/cli/show/templates.py
+++ b/vmanage/cli/show/templates.py
@@ -23,9 +23,9 @@ def templates(ctx, template_type, diff, default, name, json):
     """
     Show template information
     """
-    device_templates = DeviceTemplates(ctx.auth, ctx.host)
-    feature_templates = FeatureTemplates(ctx.auth, ctx.host)
-    template_data = TemplateData(ctx.auth, ctx.host)
+    device_templates = DeviceTemplates(ctx.auth, ctx.host, ctx.port)
+    feature_templates = FeatureTemplates(ctx.auth, ctx.host, ctx.port)
+    template_data = TemplateData(ctx.auth, ctx.host, ctx.port)
     pp = pprint.PrettyPrinter(indent=2)
 
     if name:

--- a/vmanage/cli/show/vbond.py
+++ b/vmanage/cli/show/vbond.py
@@ -9,7 +9,7 @@ def vbond(ctx):
     Get IP address and port for the configured vBond
     """
 
-    vmanage_settings = Settings(ctx.auth, ctx.host)
+    vmanage_settings = Settings(ctx.auth, ctx.host, ctx.port)
     result = vmanage_settings.get_vmanage_vbond()
     if 'domainIp' in result:
         click.echo('{}:{}'.format(result['domainIp'], result['port']))


### PR DESCRIPTION
Includes the code fix for #70. 

With this we can set port number using the option `--port` and run the SDK on the vManage deployments which are accessible through port numbers other than `443`

Example IP/DNS, port and credentials variables would be as below. 

```
export VMANAGE_HOST="10.10.20.90"
export VMANAGE_PORT=8443
export VMANAGE_USERNAME="admin"
export VMANAGE_PASSWORD="admin"
```

For the above env variables, vManage base URL would be `https://10.10.20.90:8443/` so I have changed the class object instantiation in all the SDK files to include `ctx.port` as the input parameter. 

`--port` is an optional parameter with default value `443`