### PR TITLE
check config type before attaching template

### DIFF
--- a/vmanage/api/device_templates.py
+++ b/vmanage/api/device_templates.py
@@ -306,7 +306,7 @@ class DeviceTemplates(object):
             raise Exception(f"Could not retrieve input for template {template_id}")
         return action_id
 
-    def attach_to_template(self, template_id, uuid, system_ip, host_name, site_id, variables):
+    def attach_to_template(self, template_id, config_type, uuid, system_ip, host_name, site_id, variables):
         """Attach and device to a template
 
         Args:
@@ -348,7 +348,13 @@ class DeviceTemplates(object):
                 "isMasterEdited": False
             }]
         }
-        url = f"{self.base_url}template/device/config/attachfeature"
+        if config_type == 'file':
+            url = f"{self.base_url}template/device/config/attachcli"
+        elif config_type == 'template':
+            url = f"{self.base_url}template/device/config/attachfeature"
+        else:
+            raise Exception('Got invalid Config Type')
+
         response = HttpMethods(self.session, url).request('POST', payload=json.dumps(payload))
         if 'json' in response and 'id' in response['json']:
             action_id = response['json']['id']

--- a/vmanage/data/template_data.py
+++ b/vmanage/data/template_data.py
@@ -299,6 +299,7 @@ class TemplateData(object):
                         raise Exception(f"Cannot find UUID for {attachment['host_name']}")
 
                 template_id = device_template_dict[attachment['template']]['templateId']
+                config_type = device_template_dict[attachment['template']]['configType']
                 attached_uuid_list = self.device_templates.get_attachments(template_id, key='uuid')
                 if device_uuid in attached_uuid_list:
                     # The device is already attached to the template.  We need to see if any of
@@ -316,7 +317,7 @@ class TemplateData(object):
                             changed = True
                     if changed:
                         if not check_mode and update:
-                            action_id = self.device_templates.attach_to_template(template_id, device_uuid,
+                            action_id = self.device_templates.attach_to_template(template_id, config_type, device_uuid,
                                                                                  attachment['system_ip'],
                                                                                  attachment['host_name'],
                                                                                  attachment['site_id'],
@@ -324,7 +325,7 @@ class TemplateData(object):
                             action_id_list.append(action_id)
                 else:
                     if not check_mode:
-                        action_id = self.device_templates.attach_to_template(template_id, device_uuid,
+                        action_id = self.device_templates.attach_to_template(template_id, config_type, device_uuid,
                                                                              attachment['system_ip'],
                                                                              attachment['host_name'],
                                                                              attachment['site_id'],


### PR DESCRIPTION
When attaching variables in function `attach_to_template()` from attachments.json file, the function `attach_to_template()`  was using the API endpoint `template/device/config/attachfeature`.

`attachfeature` API endpoint is only applicable when device/feature templates are used. we need to use the `attachcli` API endpoint for the CLI templates. 

added the check to see the configType and invoke either `attachfeature` or `attachcli` API endpoint as applicable. 

this commit would also fix the issues related to #68 