### PR TITLE
Use specific policy definition type lists per vManage version

### DIFF
--- a/vmanage/api/policy_definitions.py
+++ b/vmanage/api/policy_definitions.py
@@ -11,7 +11,7 @@ from vmanage.utils import list_to_dict
 
 definition_types_19_2_0 = [
     "data", "approute", "control", "cflowd", "mesh", "hubandspoke", "vpnmembershipgroup", "qosmap", "rewriterule",
-    "acl", "aclv6", "vedgeroute", "zonebasedfw", "intrusionprevention", "urlfiltering", "advancedMalwareProtection", 
+    "acl", "aclv6", "vedgeroute", "zonebasedfw", "intrusionprevention", "urlfiltering", "advancedMalwareProtection",
     "dnssecurity"
 ]
 
@@ -23,6 +23,7 @@ definition_types_19_3_0 = [
 ]
 
 all_definition_types = list(set(definition_types_19_2_0) | set(definition_types_19_3_0))
+
 
 class PolicyDefinitions(object):
     """vManage Policy Definitions API

--- a/vmanage/api/policy_definitions.py
+++ b/vmanage/api/policy_definitions.py
@@ -6,15 +6,23 @@ import json
 from vmanage.api.http_methods import HttpMethods
 from vmanage.api.policy_lists import PolicyLists
 from vmanage.data.parse_methods import ParseMethods
+from vmanage.api.utilities import Utilities
 from vmanage.utils import list_to_dict
 
-definition_types = [
+definition_types_19_2_0 = [
+    "data", "approute", "control", "cflowd", "mesh", "hubandspoke", "vpnmembershipgroup", "qosmap", "rewriterule",
+    "acl", "aclv6", "vedgeroute", "zonebasedfw", "intrusionprevention", "urlfiltering", "advancedMalwareProtection", 
+    "dnssecurity"
+]
+
+definition_types_19_3_0 = [
     "data", "approute", "control", "cflowd", "mesh", "hubandspoke", "vpnmembershipgroup", "qosmap", "rewriterule",
     "acl", "aclv6", "deviceaccesspolicy", "deviceaccesspolicyv6", "vedgeroute", "zonebasedfw", "intrusionprevention",
     "urlfiltering", "advancedMalwareProtection", "dnssecurity", "ssldecryption", "fxoport", "fxsport", "fxsdidport",
     "dialpeer", "srstphoneprofile"
 ]
 
+all_definition_types = list(set(definition_types_19_2_0) | set(definition_types_19_3_0))
 
 class PolicyDefinitions(object):
     """vManage Policy Definitions API
@@ -38,6 +46,24 @@ class PolicyDefinitions(object):
         self.port = port
         self.base_url = f'https://{self.host}:{self.port}/dataservice/'
         self.policy_lists = PolicyLists(self.session, self.host, self.port)
+
+        version = Utilities(self.session, self.host, self.port).get_vmanage_version()
+        if version >= '19.3.0':
+            self.definition_types = definition_types_19_3_0
+        else:
+            self.definition_types = definition_types_19_2_0
+
+    def get_definition_types(self):
+        """Return the definition types for this version of vManage
+
+        Args:
+
+        Returns:
+            result (list): List of definition types
+
+        """
+
+        return self.definition_types
 
     def delete_policy_definition(self, definition_type, definition_id):
         """Delete a Policy Definition from vManage.
@@ -116,7 +142,7 @@ class PolicyDefinitions(object):
 
         if definition_type == 'all':
             all_definitions_list = []
-            for def_type in definition_types:
+            for def_type in self.definition_types:
                 definition_list = self.get_policy_definition_list(def_type)
                 if definition_list:
                     all_definitions_list.extend(definition_list)

--- a/vmanage/cli/show/policies.py
+++ b/vmanage/cli/show/policies.py
@@ -3,7 +3,7 @@ import pprint
 import click
 from vmanage.api.policy_lists import PolicyLists
 from vmanage.api.policy_definitions import PolicyDefinitions
-from vmanage.api.policy_definitions import definition_types
+from vmanage.api.policy_definitions import all_definition_types
 from vmanage.data.policy_data import PolicyData
 from vmanage.api.local_policy import LocalPolicy
 from vmanage.api.central_policy import CentralPolicy
@@ -39,7 +39,7 @@ def list_cmd(ctx, name, json, policy_list_type):  #pylint: disable=unused-argume
               'definition_type',
               default='all',
               help="Definition type",
-              type=click.Choice(definition_types + ['all']))
+              type=click.Choice(all_definition_types + ['all']))
 @click.pass_obj
 def definition(ctx, name, json, definition_type):  #pylint: disable=unused-argument
     """


### PR DESCRIPTION
Currently, we only maintain a single list of policy definition types and attempt to retrieve them all via REST API when we export the policy definitions.  This works fine in later versions of vManage where all of the types are supported, not so much in earlier versions where they are not (exceptions were thrown in the CLI).  This PR adds code to maintain different lists per vManage version so that we can align the policy definition types with vManage.

I tested this with 19.2.1 to make sure it works without error.

Fixes #59