### PR TITLE
Improve attach_to_template() function

### DIFF
--- a/vmanage/api/device_templates.py
+++ b/vmanage/api/device_templates.py
@@ -306,49 +306,63 @@ class DeviceTemplates(object):
             raise Exception(f"Could not retrieve input for template {template_id}")
         return action_id
 
-    def attach_to_template(self, template_id, uuid, system_ip, host_name, site_id, variables):
+    def attach_to_template(self, template_id, config_type, uuid):
         """Attach and device to a template
 
         Args:
             template_id (str): The template ID to attach to
-            uuid (str): The UUID of the device to attach
-            system_ip (str): The System IP of the system to attach
-            host_name (str): The host-name of the device to attach
-            variables (dict): The variables needed by the template
+            config_type (str): Type of template i.e. device or CLI template
+            uuid (dict): The UUIDs of the device to attach and mapping for corresponding variables, system-ip, host-name
 
         Returns:
             action_id (str): Returns the action id of the attachment
 
         """
         # Construct the variable payload
-        device_template_variables = {
-            "csv-status": "complete",
-            "csv-deviceId": uuid,
-            "csv-deviceIP": system_ip,
-            "csv-host-name": host_name,
-            '//system/host-name': host_name,
-            '//system/system-ip': system_ip,
-            '//system/site-id': site_id,
-        }
-        # Make sure they passed in the required variables and map
-        # variable name -> property mapping
+
+        device_template_var_list = list()
         template_variables = self.get_template_input(template_id)
-        for entry in template_variables['columns']:
-            if entry['variable']:
-                if entry['variable'] in variables:
-                    device_template_variables[entry['property']] = variables[entry['variable']]
-                else:
-                    raise Exception(f"{entry['variable']} is missing for template {host_name}")
+
+        for device_uuid in uuid:
+
+            device_template_variables = {
+                "csv-status": "complete",
+                "csv-deviceId": device_uuid,
+                "csv-deviceIP": uuid[device_uuid]['system_ip'],
+                "csv-host-name": uuid[device_uuid]['host_name'],
+                '//system/host-name': uuid[device_uuid]['host_name'],
+                '//system/system-ip': uuid[device_uuid]['system_ip'],
+                '//system/site-id': uuid[device_uuid]['site_id'],
+            }
+
+            # Make sure they passed in the required variables and map
+            # variable name -> property mapping
+
+            for entry in template_variables['columns']:
+                if entry['variable']:
+                    if entry['variable'] in uuid[device_uuid]['variables']:
+                        device_template_variables[entry['property']] = uuid[device_uuid]['variables'][entry['variable']]
+                    else:
+                        raise Exception(f"{entry['variable']} is missing for template {uuid[device_uuid]['host_name']}")
+
+            device_template_var_list.append(device_template_variables)
 
         payload = {
             "deviceTemplateList": [{
                 "templateId": template_id,
-                "device": [device_template_variables],
+                "device": device_template_var_list,
                 "isEdited": False,
                 "isMasterEdited": False
             }]
         }
-        url = f"{self.base_url}template/device/config/attachfeature"
+
+        if config_type == 'file':
+            url = f"{self.base_url}template/device/config/attachcli"
+        elif config_type == 'template':
+            url = f"{self.base_url}template/device/config/attachfeature"
+        else:
+            raise Exception('Got invalid Config Type')
+
         response = HttpMethods(self.session, url).request('POST', payload=json.dumps(payload))
         if 'json' in response and 'id' in response['json']:
             action_id = response['json']['id']

--- a/vmanage/apps/files.py
+++ b/vmanage/apps/files.py
@@ -349,13 +349,8 @@ class Files(object):
             raise Exception("File format not supported")
         return (len(attachments_list))
 
-    def import_attachments_from_file(self,
-                                     import_file,
-                                     update=False,
-                                     check_mode=False,
-                                     name_list=None,
-                                     template_type=None):
-        """Import policy from a file.  All object Names will be translated to IDs.
+    def import_attachments_from_file(self, import_file, update=False, check_mode=False, name_list=None):
+        """Import attachments from a file.  All object Names will be translated to IDs.
 
         Args:
             import_file (str): The name of the import file
@@ -374,10 +369,11 @@ class Files(object):
             else:
                 template_data = json.load(f)
 
+        imported_attachment_list = []
         if 'vmanage_attachments' in template_data:
-            imported_attachment_list = template_data['vmanage_attachments']
-        else:
-            imported_attachment_list = []
+            for attachment in template_data['vmanage_attachments']:
+                if name_list is None or attachment['host_name'] in name_list:
+                    imported_attachment_list.append(attachment)
 
         # Process the device templates
         result = self.template_data.import_attachment_list(imported_attachment_list,

--- a/vmanage/cli/import_cmd/attachments.py
+++ b/vmanage/cli/import_cmd/attachments.py
@@ -7,26 +7,21 @@ from vmanage.apps.files import Files
 @click.option('--check/--no-check', help="Just check (no changes)", default=False)
 @click.option('--update/--no-update', help="Update if exists", default=False)
 # @click.option('--diff/--no-diff', help="Show Diffs", default=False)
-@click.option('--name', '-n', multiple=True)
-@click.option('--type',
-              '-t',
-              'template_type',
-              help="Template type",
-              type=click.Choice(['device', 'feature']),
-              default=None)
+@click.option('--name', '-n', help="Host name of the device", multiple=True)
 @click.pass_obj
-def attachments(ctx, input_file, check, update, name, template_type):
+def attachments(ctx, input_file, check, update, name):
     """
     Import attachments from file
     """
     vmanage_files = Files(ctx.auth, ctx.host, ctx.port)
 
-    click.echo(f'Importing attachments from {input_file}')
-    result = vmanage_files.import_attachments_from_file(input_file,
-                                                        update=update,
-                                                        check_mode=check,
-                                                        name_list=name,
-                                                        template_type=template_type)
+    if name:
+        click.echo(f'Importing attachment(s) for {",".join(name)} from {input_file}')
+        result = vmanage_files.import_attachments_from_file(input_file, update=update, check_mode=check, name_list=name)
+    else:
+        click.echo(f'Importing attachment(s) from {input_file}')
+        result = vmanage_files.import_attachments_from_file(input_file, update=update, check_mode=check)
+
     print(f"Attachment Updates: {len(result['updates'])}")
     for host, failure in result['failures'].items():
         click.secho(f"{host}: {failure}", err=True, fg='red')


### PR DESCRIPTION
In current implementation `attach_to_template()` runs one API call to attach each device to a template. However common deployment scenario is to attach the multiple devices to one device template and for those scenarios we can run one API call with payload for all the device-uuids. It improves the performance of SDK a lot, for example see the below time analysis. 

**Before fix:**

time vmanage import attachments -f ../python-viptela/devnet-sandbox-variables.yaml
Importing attachments from ../python-viptela/devnet-sandbox-variables.yaml
Attachment Updates: 11
vmanage import attachments -f ../python-viptela/devnet-sandbox-variables.yaml  1.26s user 0.09s system 0% cpu **3:39.68** total

**After fix:**

time vmanage import attachments -f devnet-sandbox-variables.yaml
Importing attachment(s) from devnet-sandbox-variables.yaml
Attachment Updates: 11
vmanage import attachments -f devnet-sandbox-variables.yaml  0.68s user 0.10s system 0% cpu **2:34.64** total

In the above example, I had total 11 devices in deployment with 8 devices attached to one device template and 3 devices attached to 3 device templates respectively.
 
In the current code we would execute **11** API calls because it is one API call per device. In the new code we would execute **4** API calls because it is executed per template with all devices attached to that template.  

PR contains the code needed for enhancement #76 