### PR TITLE
Get attached config for device in staging

### DIFF
--- a/vmanage/api/device_templates.py
+++ b/vmanage/api/device_templates.py
@@ -444,3 +444,17 @@ class DeviceTemplates(object):
         url = f"{self.base_url}template/config/running/{uuid}"
         response = HttpMethods(self.session, url).request('GET')
         return ParseMethods.parse_config(response)
+
+    def get_device_attached_config(self, uuid):
+        """
+        Get the attached configuration of a specific device.
+
+        Args:
+            uuid (str): UUID of device
+        Returns:
+            result (str): The running configuration of the specified device.
+        """
+        url = f"{self.base_url}template/config/attached/{uuid}"
+        response = HttpMethods(self.session, url).request('GET')
+        return ParseMethods.parse_config(response)
+

--- a/vmanage/api/device_templates.py
+++ b/vmanage/api/device_templates.py
@@ -457,4 +457,3 @@ class DeviceTemplates(object):
         url = f"{self.base_url}template/config/attached/{uuid}"
         response = HttpMethods(self.session, url).request('GET')
         return ParseMethods.parse_config(response)
-

--- a/vmanage/api/device_templates.py
+++ b/vmanage/api/device_templates.py
@@ -452,7 +452,7 @@ class DeviceTemplates(object):
         Args:
             uuid (str): UUID of device
         Returns:
-            result (str): The running configuration of the specified device.
+            result (str): The attached configuration of the specified device.
         """
         url = f"{self.base_url}template/config/attached/{uuid}"
         response = HttpMethods(self.session, url).request('GET')


### PR DESCRIPTION
Allows to check configuration on devices in "staging" state whereas get_device_running_config is only for "valid" state devices