### PR TITLE
Print as proper json #117 

### DIFF
--- a/vmanage/cli/show/control.py
+++ b/vmanage/cli/show/control.py
@@ -1,9 +1,9 @@
 import ipaddress
-import pprint
 
 import click
 from vmanage.api.device import Device
 from vmanage.api.monitor_network import MonitorNetwork
+from vmanage.cli.show.print_utils import print_json
 
 
 @click.command()
@@ -37,16 +37,13 @@ def connections(ctx, device, json):
         click.echo(
             "SYSTEM IP       TYPE    PROT SYSTEM IP       ID     ID     PRIVATE IP      PUBLIC IP       LOCAL COLOR      PROXY STATE UPTIME"
         )
-        click.echo(
-            "-------------------------------------------------------------------------------------------------------------------"
-        )
+        click.echo("-" * 115)
 
     for dev in device_list:
         try:
             control_connections = mn.get_control_connections(dev)
             if json:
-                pp = pprint.PrettyPrinter(indent=2)
-                pp.pprint(control_connections)
+                print_json(control_connections)
             else:
                 for connection in control_connections:
                     click.echo(
@@ -85,14 +82,11 @@ def connections_history(ctx, device, json):
         click.echo(
             "TYPE     PROTOCOL SYSTEM IP        ID    ID     PRIVATE IP       PORT    PUBLIC IP        PORT   LOCAL COLOR      STATE       ERROR   ERROR"
         )
-        click.echo(
-            "-------------------------------------------------------------------------------------------------------------------------------------------"
-        )
+        click.echo("-" * 139)
     try:
         control_connections_history = mn.get_control_connections_history(system_ip)
         if json:
-            pp = pprint.PrettyPrinter(indent=2)
-            pp.pprint(control_connections_history)
+            print_json(control_connections_history)
         else:
             for connection in control_connections_history:
                 click.echo(

--- a/vmanage/cli/show/device.py
+++ b/vmanage/cli/show/device.py
@@ -1,7 +1,8 @@
-import pprint
 import ipaddress
+
 import click
 from vmanage.api.device import Device
+from vmanage.cli.show.print_utils import print_json
 
 
 @click.command()
@@ -23,7 +24,6 @@ def status(ctx, dev, device_type, json):  #pylint: disable=unused-argument
     vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
     # output = mn.get_control_connections_history(sysip)
     # vmanage_session = ctx.obj
-    pp = pprint.PrettyPrinter(indent=2)
 
     if dev:
         # Check to see if we were passed in a device IP address or a device name
@@ -34,13 +34,13 @@ def status(ctx, dev, device_type, json):  #pylint: disable=unused-argument
             device_dict = vmanage_device.get_device_status(dev, key='host-name')
 
         if device_dict:
-            pp.pprint(device_dict)
+            print_json(device_dict)
         else:
             click.secho(f"Could not find device {dev}", err=True, fg='red')
     else:
         device_list = vmanage_device.get_device_status_list()
         if json:
-            pp.pprint(device_list)
+            print_json(device_list)
         else:
             click.echo(
                 f"{'Hostname':20} {'System IP':15} {'Model':15} {'Site':6} {'Status':9} {'BFD':>3} {'OMP':>3} {'CON':>3} {'Version':8} {'UUID':40} {'Serial'}"
@@ -81,7 +81,6 @@ def config(ctx, dev, device_type, json):
     Show device config information
     """
     vmanage_device = Device(ctx.auth, ctx.host, ctx.port)
-    pp = pprint.PrettyPrinter(indent=2)
 
     #pylint: disable=too-many-nested-blocks
     if dev:
@@ -99,7 +98,7 @@ def config(ctx, dev, device_type, json):
                 device_type = 'vedges'
 
             device_config = vmanage_device.get_device_config(device_type, device_dict['system-ip'])
-            pp.pprint(device_config)
+            print_json(device_config)
         else:
             click.secho(f"Could not find device {dev}", err=True, fg='red')
 
@@ -112,7 +111,7 @@ def config(ctx, dev, device_type, json):
             device_list = vmanage_device.get_device_config_list('controllers')
 
             if json:
-                pp.pprint(device_list)
+                print_json(device_list)
             else:
                 for device_entry in device_list:
                     if 'template' in device_entry:
@@ -135,7 +134,7 @@ def config(ctx, dev, device_type, json):
         if device_type in ['all', 'edge']:
             device_list = vmanage_device.get_device_config_list('vedges')
             if json:
-                pp.pprint(device_list)
+                print_json(device_list)
             else:
                 for device_entry in device_list:
                     if 'host-name' in device_entry:

--- a/vmanage/cli/show/interface.py
+++ b/vmanage/cli/show/interface.py
@@ -1,8 +1,8 @@
 import ipaddress
-import pprint
 
 import click
 from vmanage.api.device import Device
+from vmanage.cli.show.print_utils import print_json
 
 
 @click.command(name='list')
@@ -28,16 +28,13 @@ def list_interface(ctx, device, json):
 
     if not json:
         click.echo("IFNAME            VPNID  IP ADDR          MAC ADDR                  OPER STATE            DESC")
-        click.echo(
-            "----------------------------------------------------------------------------------------------------------------------"
-        )
+        click.echo("-" * 118)
 
     for dev in device_list:
         interfaces = vmanage_device.get_device_data('interface', dev)
         for iface in interfaces:
             if json:
-                pp = pprint.PrettyPrinter(indent=2)
-                pp.pprint(iface)
+                print_json(iface)
             else:
                 if 'hwaddr' not in iface:
                     iface['hwaddr'] = ''

--- a/vmanage/cli/show/omp.py
+++ b/vmanage/cli/show/omp.py
@@ -1,9 +1,9 @@
 import ipaddress
-import pprint
 
 import click
 from vmanage.api.device import Device
 from vmanage.api.monitor_network import MonitorNetwork
+from vmanage.cli.show.print_utils import print_json
 
 
 @click.command()
@@ -36,8 +36,7 @@ def peers(ctx, device, json):
     # try:
     omp_peers = mn.get_omp_peers(system_ip)
     if json:
-        pp = pprint.PrettyPrinter(indent=2)
-        pp.pprint(omp_peers)
+        print_json(omp_peers)
     else:
         for peer in omp_peers:
             click.echo(
@@ -74,8 +73,7 @@ def received(ctx, device, json):
     # try:
     omp_peers = mn.get_omp_routes_received(system_ip)
     if json:
-        pp = pprint.PrettyPrinter(indent=2)
-        pp.pprint(omp_peers)
+        print_json(omp_peers)
     else:
         for peer in omp_peers:
             click.echo(
@@ -112,8 +110,7 @@ def advertised(ctx, device, json):
     # try:
     omp_peers = mn.get_omp_routes_advertised(system_ip)
     if json:
-        pp = pprint.PrettyPrinter(indent=2)
-        pp.pprint(omp_peers)
+        print_json(omp_peers)
     else:
         for peer in omp_peers:
             if 'protocol' in peer:

--- a/vmanage/cli/show/policies.py
+++ b/vmanage/cli/show/policies.py
@@ -1,13 +1,13 @@
 import pprint
 
 import click
-from vmanage.api.policy_lists import PolicyLists
-from vmanage.api.policy_definitions import PolicyDefinitions
-from vmanage.api.policy_definitions import all_definition_types
-from vmanage.data.policy_data import PolicyData
-from vmanage.api.local_policy import LocalPolicy
 from vmanage.api.central_policy import CentralPolicy
+from vmanage.api.local_policy import LocalPolicy
+from vmanage.api.policy_definitions import (PolicyDefinitions, all_definition_types)
+from vmanage.api.policy_lists import PolicyLists
 from vmanage.api.security_policy import SecurityPolicy
+from vmanage.cli.show.print_utils import print_json
+from vmanage.data.policy_data import PolicyData
 
 
 @click.command('list')
@@ -76,7 +76,7 @@ def central(ctx, name, json):  #pylint: disable=unused-argument
         central_policy_dict = central_policy.get_central_policy_dict()
         if name in central_policy_dict:
             if json:
-                pp.pprint(central_policy_dict[name])
+                print_json(central_policy_dict[name])
             else:
                 preview = central_policy.get_central_policy_preview(central_policy_dict[name]['policyId'])
                 pp.pprint(preview)
@@ -122,7 +122,7 @@ def security(ctx, name, json):  #pylint: disable=unused-argument
         security_policy_dict = security_policy.get_security_policy_dict()
         if name in security_policy_dict:
             if json:
-                pp.pprint(security_policy_dict[name])
+                print_json(security_policy_dict[name])
             else:
                 preview = security_policy.get_security_policy_preview(security_policy_dict[name]['policyId'])
                 pp.pprint(preview)

--- a/vmanage/cli/show/print_utils.py
+++ b/vmanage/cli/show/print_utils.py
@@ -1,0 +1,10 @@
+import json
+
+import click
+
+
+def print_json(obj: dict):
+    """
+    Print a dictionary object as json
+    """
+    click.echo(json.dumps(obj, indent=2))

--- a/vmanage/cli/show/route.py
+++ b/vmanage/cli/show/route.py
@@ -1,8 +1,8 @@
 import ipaddress
-import pprint
 
 import click
 from vmanage.api.device import Device
+from vmanage.cli.show.print_utils import print_json
 
 
 @click.command()
@@ -33,8 +33,7 @@ def table(ctx, device, json):
     routes = vmanage_device.get_device_data('ip/routetable', system_ip)
     for rte in routes:
         if json:
-            pp = pprint.PrettyPrinter(indent=2)
-            pp.pprint(rte)
+            print_json(rte)
         else:
             if 'nexthop-addr' not in rte:
                 rte['nexthop-addr'] = ''

--- a/vmanage/cli/show/templates.py
+++ b/vmanage/cli/show/templates.py
@@ -77,9 +77,8 @@ def templates(ctx, template_type, diff, default, name, json):
                 for template in device_template_list:
                     attached_devices = device_templates.get_template_attachments(template['templateId'])
                     click.echo(
-                        f"{template['templateName'][:30]:30} {template['configType'][:10]:10} {len(attached_devices):<9} \
-                          {template['deviceType'][:16]:16} "
-                    )
+                        f"{template['templateName'][:30]:30} {template['configType'][:10]:10} {len(attached_devices):<9} "
+                        f"{template['deviceType'][:16]:16} ")
                 click.echo()
             else:
                 print_json(device_template_list)
@@ -91,8 +90,7 @@ def templates(ctx, template_type, diff, default, name, json):
                 click.echo("------------------------------------------------------------------------------------")
                 for template in feature_template_list:
                     click.echo(
-                        f"{template['templateName'][:30]:30} {template['templateType'][:20]:20} {template['attachedMastersCount']:<10} \
-                          {template['devicesAttached']:<9} {','.join(template['deviceType'])[:16]:16}"
-                    )
+                        f"{template['templateName'][:30]:30} {template['templateType'][:20]:20} {template['attachedMastersCount']:<10} "
+                        f"{template['devicesAttached']:<9} {','.join(template['deviceType'])[:16]:16}")
             else:
                 print_json(feature_template_list)

--- a/vmanage/cli/show/templates.py
+++ b/vmanage/cli/show/templates.py
@@ -4,6 +4,7 @@ import click
 import dictdiffer
 from vmanage.api.device_templates import DeviceTemplates
 from vmanage.api.feature_templates import FeatureTemplates
+from vmanage.cli.show.print_utils import print_json
 from vmanage.data.template_data import TemplateData
 
 
@@ -63,7 +64,7 @@ def templates(ctx, template_type, diff, default, name, json):
                     diff = dictdiffer.diff(template, diff_template, ignore=diff_ignore)
                     pp.pprint(list(diff))
             else:
-                pp.pprint(template)
+                print_json(template)
         else:
             click.secho(f"Cannot find template named {name}", fg="red")
     else:
@@ -76,11 +77,12 @@ def templates(ctx, template_type, diff, default, name, json):
                 for template in device_template_list:
                     attached_devices = device_templates.get_template_attachments(template['templateId'])
                     click.echo(
-                        f"{template['templateName'][:30]:30} {template['configType'][:10]:10} {len(attached_devices):<9} {template['deviceType'][:16]:16} "
+                        f"{template['templateName'][:30]:30} {template['configType'][:10]:10} {len(attached_devices):<9} \
+                          {template['deviceType'][:16]:16} "
                     )
                 click.echo()
             else:
-                pp.pprint(device_template_list)
+                print_json(device_template_list)
         if template_type in ['feature', None]:
             feature_template_list = feature_templates.get_feature_template_list(factory_default=default)
             if not json:
@@ -89,7 +91,8 @@ def templates(ctx, template_type, diff, default, name, json):
                 click.echo("------------------------------------------------------------------------------------")
                 for template in feature_template_list:
                     click.echo(
-                        f"{template['templateName'][:30]:30} {template['templateType'][:20]:20} {template['attachedMastersCount']:<10} {template['devicesAttached']:<9} {','.join(template['deviceType'])[:16]:16}"
+                        f"{template['templateName'][:30]:30} {template['templateType'][:20]:20} {template['attachedMastersCount']:<10} \
+                          {template['devicesAttached']:<9} {','.join(template['deviceType'])[:16]:16}"
                     )
             else:
-                pp.pprint(feature_template_list)
+                print_json(feature_template_list)

--- a/vmanage/data/policy_data.py
+++ b/vmanage/data/policy_data.py
@@ -59,8 +59,10 @@ class PolicyData(object):
                                                                       cache=False)
             if policy_list['name'] in policy_list_dict:
                 existing_list = policy_list_dict[policy_list['name']]
-                diff_ignore = set(
-                    ['listId', 'referenceCount', 'references', 'owner', 'lastUpdated', 'activatedId', 'policyId', 'isActivatedByVsmart'])
+                diff_ignore = set([
+                    'listId', 'referenceCount', 'references', 'owner', 'lastUpdated', 'activatedId', 'policyId',
+                    'isActivatedByVsmart'
+                ])
                 diff = list(dictdiffer.diff(existing_list, policy_list, ignore=diff_ignore))
                 if diff:
                     policy_list_updates.append({'name': policy_list['name'], 'diff': diff})


### PR DESCRIPTION
Modified cli.show commands with --json flag to print out result as proper json instead of python dictionary  to resolve issue #117 . 
The module cli.show.print_utils was added to keep the json package in a separate namespace to avoid conflict with the cli-flag (--json) with the same name.
