### PR TITLE
Fixed post_device function

### DIFF
--- a/vmanage/api/device.py
+++ b/vmanage/api/device.py
@@ -211,11 +211,19 @@ class Device(object):
         """Add control plane device
 
         Args:
-            device_id (str): uuid for device object
+            device_ip (str): device interface IP
+            personality (str): controller type (vmanage, vsmart, vbond)
+            username (str): device username
+            password (str): device password
 
         Returns:
             result (list): Device status        
         """
+        url = f"{self.base_url}system/device"
+        payload = f"{{'deviceIP':'{device_ip}','username':'{username}','password':'{password}','personality':'{personality}','generateCSR':'false'}}"
+        response = HttpMethods(self.session, url).request('POST', payload=payload,timeout=35)
+        result = ParseMethods.parse_status(response)
+        return result
  
     def post_reset_interface(self, device_ip, vpn_id, ifname):
         """Reset an Interface


### PR DESCRIPTION
Fixes #145 post_device function: added correct API call and timeout 35 seconds. Note that this API waits for vManage to establish NETCONF session to new controllers, so the API response might come up to 30 seconds after the requests was sent. This is why timeout is set to 35 seconds. The generateCSR option is set to false as we have a separate function for that under python-viptela/vmanage/api/certificate.py