### PR TITLE
Fix regexp matching variables

### DIFF
--- a/vmanage/api/device_templates.py
+++ b/vmanage/api/device_templates.py
@@ -184,7 +184,7 @@ class DeviceTemplates(object):
             if 'header' in response['json'] and 'columns' in response['json']['header']:
                 column_list = response['json']['header']['columns']
 
-                regex = re.compile(r'\((?P<variable>[^(]+)\)')
+                regex = re.compile(r'\((?P<variable>[^(]+)\)$')
 
                 for column in column_list:
                     if column['editable']:


### PR DESCRIPTION
The regexp in `device_template.py` that matches the variable names from the `title` is matching the first parentheses. I think we should match the last one instead. Otherwise it will match something in the description, if it contains a parentheses. 

Consider the following example:

`"title": "Shaping Rate (Kbps)(internet_shaping_rate)"`

will currently be matched and parsed as `variable = 'Kbps'`

where it should be `variable = 'internet_shapeing_rate'`.