### PR TITLE
Fix no version key provided by vmanage during authentication

### DIFF
--- a/vmanage/api/authentication.py
+++ b/vmanage/api/authentication.py
@@ -74,7 +74,7 @@ class Authentication(object):
 
             version = Utilities(self.session, self.host, self.port).get_vmanage_version()
 
-            if version >= '19.2.0':
+            if version is None or version >= '19.2.0':
                 api = 'client/token'
                 url = f'{self.base_url}{api}'
                 response = self.session.get(url=url, timeout=self.timeout)

--- a/vmanage/api/utilities.py
+++ b/vmanage/api/utilities.py
@@ -47,7 +47,9 @@ class Utilities(object):
         url = self.base_url + api
         response = HttpMethods(self.session, url).request('GET')
         result = ParseMethods.parse_data(response)
-        version = result[0]['version']
+        version = None
+        if "version" in result[0]:
+            version = result[0]['version']
         return version
 
     def waitfor_action_completion(self, action_id):


### PR DESCRIPTION
All,

the applied fix is intended to correct an issue during authentication where vManage (SDWAN Manager) no longer provides the version information for controllers (at least happens with SDWAN release 20.9.4). 


Best regards
Sven